### PR TITLE
Added support for a repository containing the missing restlet libraries

### DIFF
--- a/ivy/ivy-settings.xml
+++ b/ivy/ivy-settings.xml
@@ -1,7 +1,12 @@
 
 <ivysettings>
-    <settings defaultResolver="central"/>
+    <settings defaultResolver="resolver-chain"/>
     <resolvers>
         <ibiblio name="central" m2compatible="true"/>
+        <ibiblio name="restlet" m2compatible="true" root="http://maven.restlet.com/"/>
+        <chain name="resolver-chain">
+            <resolver ref="central"/>
+            <resolver ref="restlet"/>
+        </chain>
     </resolvers>
 </ivysettings>


### PR DESCRIPTION
The current Ant build fails to resolve the restlet dependencies. This pull request contains an update to ivy-settings.xml to resolve the missing dependency.
